### PR TITLE
Fix Circle

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,4 @@ max-line-length = 80
 [pytest]
 DJANGO_SETTINGS_MODULE=freemusicninja.settings
 addopts = --cov . --cov-report term --cov-report html
+norecursedirs = venv  # Excluded due to Circle CI bug


### PR DESCRIPTION
Exclude venv directories for pytest because Circle makes a virtualenv in a directory called `venv` inside our project.
