### PR TITLE
Remove leading and tailing whitespace from searches

### DIFF
--- a/similarities/tests/test_utils.py
+++ b/similarities/tests/test_utils.py
@@ -91,6 +91,14 @@ class GetSimilarTest(DjangoTestCase):
         artists = utils.get_similar(self.name)
         self.assertSequenceEqual(artists, [self.cc_artist])
 
+    def test_leading_whitespace(self):
+        """Test has_similarities strips whitespace."""
+        name = " Hussalonia"
+        self.has_similarities.return_value = False
+        utils.get_similar(name)
+        general_artist = GeneralArtist.objects.latest('pk')
+        assert general_artist.name == name.strip()
+
     def test_zero_weight(self):
         name = "Tom Waits"
         other_artist = GeneralArtist.objects.create(name=name)

--- a/similarities/utils.py
+++ b/similarities/utils.py
@@ -35,6 +35,7 @@ def add_new_similarities(artist):
 
 
 def get_similar(name):
+    name = name.strip()
     artist, _ = GeneralArtist.objects.get_or_create(
         normalized_name=name.upper(), defaults={'name': name})
     if not has_similarities(artist):


### PR DESCRIPTION
This prevents leading and trailing whitespace from entering the `GeneralArtist` names when searching.

Fixes https://app.getsentry.com/freemusicninja/apifreemusicninja/group/42604986/
