### PR TITLE
Bugfix: Fix similarity list view when empty

### DIFF
--- a/artists/serializers.py
+++ b/artists/serializers.py
@@ -18,15 +18,21 @@ class SimilaritySerializer(serializers.ModelSerializer):
     cc_artist = serializers.PrimaryKeyRelatedField(style={'input_type': "number"},
                                                    queryset=Artist.objects.all())
     weight = serializers.IntegerField(default=0)
+    user = serializers.PrimaryKeyRelatedField(
+        read_only=True, default=serializers.CurrentUserDefault())
 
     def validate_other_artist(self, value):
         artist, _ = GeneralArtist.objects.get_or_create(
             normalized_name=value.upper(), defaults={'name': value})
         return artist
 
+    def to_representation(self, instance):
+        d = super().to_representation(instance)
+        d.pop('user')
+        return d
+
     class Meta:
         model = UserSimilarity
-        exclude = ('user',)
         validators = [
             serializers.UniqueTogetherValidator(
                 queryset=UserSimilarity.objects.all(),

--- a/artists/tests/test_api.py
+++ b/artists/tests/test_api.py
@@ -72,6 +72,10 @@ class SimilarTest(APITestCase):
             user=self.user, other_artist=self.general_artists[0])
         self.check_retrieve_list(artist, [similarity])
 
+    def test_empty_list_similar(self):
+        artist = Artist.objects.create(name="Brad Sucks")
+        self.check_retrieve_list(artist, [])
+
     def test_create_similar(self):
         artist = Artist.objects.create(name="Brad Sucks")
         url = reverse('usersimilarity-list')

--- a/artists/views.py
+++ b/artists/views.py
@@ -36,11 +36,3 @@ class SimilarViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         return super().get_queryset().filter(user=self.request.user)
-
-    def get_serializer(self, instance=None, *args, **kwargs):
-        try:
-            instance = instance or self.get_object()
-        except (Http404, AssertionError):
-            instance = self.get_queryset().model()
-        instance.user = self.request.user
-        return super().get_serializer(instance, *args, **kwargs)


### PR DESCRIPTION
Pretty obscure bug when a user without any similarities created tries to retrieve their list of similarities. This is actually a much better way to handle it anyway. Added a test for the empty list case.

https://app.getsentry.com/freemusicninja/apifreemusicninja/group/48371104/