### PR TITLE
Move unweighing of low content artists into view

### DIFF
--- a/artists/tests/test_api.py
+++ b/artists/tests/test_api.py
@@ -185,12 +185,12 @@ class SimilarTest(APITestCase):
 
 
 @patch('bandcamp.tasks.check_for_cc')
+@patch('similarities.utils.has_similarities', return_value=True)
 class GroupSearchResultsTest(APITestCase):
 
     """Tests for SimilarityManager."""
 
-    def test_high_track_count(self, mock_bandcamp_task):
-        print(Similarity.objects.all())
+    def test_high_track_count(self, mock_similar_from_api, mock_bandcamp_task):
         similarity_with_tracks = SimilarityFactory(
             weight=5, cc_artist=factories.HyperlinkFactory(num_tracks=20).artist)
         SimilarityFactory(
@@ -201,13 +201,9 @@ class GroupSearchResultsTest(APITestCase):
             {'name': similarity_with_tracks.other_artist.name},
             format='json',
         )
-        print(Similarity.objects.all())
-        from bandcamp import models
-        print(models.Artist.objects.all())
         assert response.data[0]['id'] == similarity_with_tracks.cc_artist.pk
 
-    def test_low_track_count(self, mock_bandcamp_task):
-        print(Similarity.objects.all())
+    def test_low_track_count(self, mock_similar_from_api, mock_bandcamp_task):
         similarity_with_tracks = SimilarityFactory(
             weight=1, cc_artist=factories.HyperlinkFactory(num_tracks=20).artist)
         SimilarityFactory(
@@ -218,7 +214,4 @@ class GroupSearchResultsTest(APITestCase):
             {'name': similarity_with_tracks.other_artist.name},
             format='json',
         )
-        print(Similarity.objects.all())
-        from bandcamp import models
-        print(models.Artist.objects.all())
         assert response.data[0]['id'] == similarity_with_tracks.cc_artist.pk

--- a/artists/tests/test_api.py
+++ b/artists/tests/test_api.py
@@ -1,4 +1,3 @@
-import json
 from unittest.mock import patch
 
 from django.core.urlresolvers import reverse
@@ -9,6 +8,9 @@ from rest_framework.test import APITestCase
 from artists.models import Artist
 from echonest.models import SimilarResponse
 from similarities.models import GeneralArtist, Similarity, UserSimilarity
+from similarities.tests.factories import SimilarityFactory
+
+from . import factories
 
 
 class ArtistTest(APITestCase):
@@ -180,3 +182,43 @@ class SimilarTest(APITestCase):
         assert new_similarity.other_artist != old_similarity.other_artist
         assert new_similarity.weight == weight
         assert old_similarity.weight == 0
+
+
+@patch('bandcamp.tasks.check_for_cc')
+class GroupSearchResultsTest(APITestCase):
+
+    """Tests for SimilarityManager."""
+
+    def test_high_track_count(self, mock_bandcamp_task):
+        print(Similarity.objects.all())
+        similarity_with_tracks = SimilarityFactory(
+            weight=5, cc_artist=factories.HyperlinkFactory(num_tracks=20).artist)
+        SimilarityFactory(
+            weight=1, cc_artist=factories.HyperlinkFactory(num_tracks=20).artist,
+            other_artist=similarity_with_tracks.other_artist)
+        response = self.client.get(
+            reverse('artist-list'),
+            {'name': similarity_with_tracks.other_artist.name},
+            format='json',
+        )
+        print(Similarity.objects.all())
+        from bandcamp import models
+        print(models.Artist.objects.all())
+        assert response.data[0]['id'] == similarity_with_tracks.cc_artist.pk
+
+    def test_low_track_count(self, mock_bandcamp_task):
+        print(Similarity.objects.all())
+        similarity_with_tracks = SimilarityFactory(
+            weight=1, cc_artist=factories.HyperlinkFactory(num_tracks=20).artist)
+        SimilarityFactory(
+            weight=5, cc_artist=factories.HyperlinkFactory(num_tracks=0).artist,
+            other_artist=similarity_with_tracks.other_artist)
+        response = self.client.get(
+            reverse('artist-list'),
+            {'name': similarity_with_tracks.other_artist.name},
+            format='json',
+        )
+        print(Similarity.objects.all())
+        from bandcamp import models
+        print(models.Artist.objects.all())
+        assert response.data[0]['id'] == similarity_with_tracks.cc_artist.pk

--- a/fma/models.py
+++ b/fma/models.py
@@ -3,7 +3,6 @@ import jsonfield
 from model_utils.models import TimeStampedModel
 
 from artists import models as artists_models
-from similarities import models as similarities_models
 
 
 class Genre(TimeStampedModel):
@@ -54,9 +53,6 @@ class Artist(TimeStampedModel):
             name='fma',
             defaults={'order': 40, 'url': self.url, 'num_tracks': self.track_set.count()},
         )
-        for other_artist in link.artist.generalartist_set.all():
-            similarities_models.Similarity.objects.update_or_create_by_artists(
-                other_artist=other_artist, cc_artist=artist)
 
     def __str__(self):
         return self.name

--- a/similarities/models.py
+++ b/similarities/models.py
@@ -5,9 +5,6 @@ from model_utils import Choices
 from model_utils.models import TimeStampedModel
 
 
-MIN_TRACKS_TO_HAVE_WEIGHT = 3
-
-
 class GeneralArtist(TimeStampedModel):
 
     """Any artist that might be searched for."""
@@ -91,16 +88,10 @@ class UserSimilarity(BaseSimilarity):
 class SimilarityManager(models.Manager):
 
     def update_or_create_by_artists(self, other_artist, cc_artist):
-        low_track_links = (cc_artist.links
-                           .filter(num_tracks__lt=MIN_TRACKS_TO_HAVE_WEIGHT)
-                           .exclude(num_tracks__gte=MIN_TRACKS_TO_HAVE_WEIGHT))
-        if low_track_links.exists():
-            weight = 0
-        else:
-            weight = (UserSimilarity.objects
-                      .filter(other_artist=other_artist,
-                              cc_artist=cc_artist)
-                      .aggregate(models.Avg('weight')))['weight__avg'] or 0
+        weight = (UserSimilarity.objects
+                  .filter(other_artist=other_artist,
+                          cc_artist=cc_artist)
+                  .aggregate(models.Avg('weight')))['weight__avg'] or 0
         return self.update_or_create(
             other_artist=other_artist,
             cc_artist=cc_artist,

--- a/similarities/tests/factories.py
+++ b/similarities/tests/factories.py
@@ -13,11 +13,20 @@ class GeneralArtistFactory(factory.DjangoModelFactory):
     class Meta:
         model = models.GeneralArtist
 
+    name = factory.LazyAttribute(lambda o: fake.sentence(nb_words=2))
 
-class UserSimilarityFactory(factory.DjangoModelFactory):
+
+class SimilarityFactory(factory.DjangoModelFactory):
     class Meta:
-        model = models.UserSimilarity
+        model = models.Similarity
+        django_get_or_create = ('other_artist', 'cc_artist')
 
     other_artist = factory.SubFactory(GeneralArtistFactory)
     cc_artist = factory.SubFactory(artists_factories.ArtistFactory)
+
+
+class UserSimilarityFactory(SimilarityFactory):
+    class Meta:
+        model = models.UserSimilarity
+
     user = factory.SubFactory(users_factories.UserFactory)

--- a/similarities/tests/test_models.py
+++ b/similarities/tests/test_models.py
@@ -70,35 +70,3 @@ class BaseSimilarityModelTest(TestCase):
 
     def test_default_weight(self):
         assert models.BaseSimilarity().weight == 0
-
-
-class SimilarityManagerTest(DjangoTestCase):
-
-    """Tests for SimilarityManager."""
-
-    def test_low_track_count(self):
-        link = HyperlinkFactory(num_tracks=0)
-        user_similarity = factories.UserSimilarityFactory(
-            weight=5, cc_artist=link.artist)
-        similarity, _ = models.Similarity.objects.update_or_create_by_artists(
-            other_artist=user_similarity.other_artist,
-            cc_artist=user_similarity.cc_artist)
-        assert similarity.weight == 0
-
-    def test_high_track_count(self):
-        link = HyperlinkFactory(num_tracks=20)
-        user_similarity = factories.UserSimilarityFactory(
-            weight=5, cc_artist=link.artist)
-        similarity, _ = models.Similarity.objects.update_or_create_by_artists(
-            other_artist=user_similarity.other_artist,
-            cc_artist=user_similarity.cc_artist)
-        assert similarity.weight == 5
-
-    def test_no_track_count(self):
-        link = HyperlinkFactory(num_tracks=None)
-        user_similarity = factories.UserSimilarityFactory(
-            weight=5, cc_artist=link.artist)
-        similarity, _ = models.Similarity.objects.update_or_create_by_artists(
-            other_artist=user_similarity.other_artist,
-            cc_artist=user_similarity.cc_artist)
-        assert similarity.weight == 5


### PR DESCRIPTION
Previously the weight was set to '0', disabling those results. This will both add those results back in, and remove the need for the adjustment for low-content cc artists to be done in the Similarity model.