### PR TITLE
Basic OAuth 2.0 support

### DIFF
--- a/freemusicninja/settings.py
+++ b/freemusicninja/settings.py
@@ -47,6 +47,7 @@ INSTALLED_APPS = (
 
     'corsheaders',
     'djangosecure',
+    'oauth2_provider',
     'raven.contrib.django.raven_compat',
     'relatives',
     'rest_framework',
@@ -110,6 +111,7 @@ AUTH_USER_MODEL = 'users.User'
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
+        'oauth2_provider.ext.rest_framework.OAuth2Authentication',
         'rest_framework.authentication.TokenAuthentication',
         'rest_framework.authentication.SessionAuthentication',
     ),

--- a/freemusicninja/urls.py
+++ b/freemusicninja/urls.py
@@ -16,6 +16,7 @@ user_router.register(r'known-artists', views.KnownArtistViewSet)
 urlpatterns = [
     url(r'^', include(router.urls)),
     url(r'^users/me/', include(user_router.urls)),
+    url(r'^oauth2/', include('oauth2_provider.urls', namespace='oauth2_provider')),
     url(r'^api-auth/', include('rest_framework.urls',
                                namespace='rest_framework')),
     url(r'^api-token-auth/',

--- a/freemusicninja/urls.py
+++ b/freemusicninja/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import include, url
 from django.contrib import admin
 from rest_framework import routers
+from oauth2_provider import views as oauth2_views
 
 from artists import views
 from users.views import UserViewSet
@@ -13,10 +14,15 @@ router.register(r'similar', views.SimilarViewSet)
 user_router = routers.SimpleRouter()
 user_router.register(r'known-artists', views.KnownArtistViewSet)
 
+oauth2_urls = [
+    url(r'^authorize/$', oauth2_views.AuthorizationView.as_view(), name="authorize"),
+    url(r'^token/$', oauth2_views.TokenView.as_view(), name="token"),
+]
+
 urlpatterns = [
     url(r'^', include(router.urls)),
     url(r'^users/me/', include(user_router.urls)),
-    url(r'^oauth2/', include('oauth2_provider.urls', namespace='oauth2_provider')),
+    url(r'^oauth2/', include(oauth2_urls, namespace='oauth2_provider')),
     url(r'^api-auth/', include('rest_framework.urls',
                                namespace='rest_framework')),
     url(r'^api-token-auth/',

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ dj-database-url==0.3.0
 django-cors-headers==0.13
 django-filter==0.8
 django-model-utils==2.2.0
+django-oauth-toolkit==0.7.2
 django-relatives==0.3.1
 djangorestframework==3.0.1
 iron-celery==0.4.3


### PR DESCRIPTION
@treyhunner, I think this should add OAuth2 as a supported authentication method. Let me know if we should remove the other token-based auth at the same time.

A couple things we should worry about... `django-oauth-toolkit` supports different permission scopes, we should get those in as well, and we need SSL set up before we move to OAuth 2.0. It will be required for all connections to the API.
